### PR TITLE
Fix sort by idea Favorites

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -45,7 +45,7 @@ export default new Vuex.Store({
       let favs = state.Favorites
       if (favs.includes(payload)){
         let itemToRemove = favs.indexOf(payload)
-        favs.splice(itemToRemove)
+        favs.splice(itemToRemove, 1)
       }
       else {
         favs.push(payload)

--- a/src/views/PublicIdeas.vue
+++ b/src/views/PublicIdeas.vue
@@ -226,15 +226,13 @@ export default {
       this.GetIdeas()
     },
     showFavorites(){
-      this.favorites = !this.favorites
-      if(this.favorites == true){
-        this.filteredIdeas = this.allIdeas.filter(idea => {
-          return this.getFavorites.includes(idea.DocID)
-        })
-      }
-      else {
-        this.GetIdeas()
-      }
+      let UpdatedIdeas = this.filteredIdeas.sort((a, b) => b.FavoritesCount.length - a.FavoritesCount.length)
+      
+      this.filteredIdeas = []
+
+      setTimeout(() => {
+        this.filteredIdeas = UpdatedIdeas        
+      }, 0.1)
     },
     SortByComp() {
       let UpdatedIdeas = this.filteredIdeas.sort((a, b) => {


### PR DESCRIPTION
What does this PR do? 
- Fixes sorting by ideas' most favorited
Previously, When ideas are sorted by favorite, they weren't sorted
Currently, When ideas are sorted by favorite, they display in descending order of most favorite to the non-favorited.
- Fix multiple favorites delete
Previously, When you unfavorite an idea, all the ideas in the array length `[favorite:]` were also unfavorited
Currently, Only idea of array length [favorite] gets deleted.

Relevant screenshot?
<img width="1158" alt="Screenshot 2019-10-26 at 12 42 50" src="https://user-images.githubusercontent.com/32167860/67618326-3a114c00-f7ee-11e9-9034-fcfc0e114544.png">

